### PR TITLE
ci: semantic release publish only when build success

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run Semantic Release
+      - name: Run Semantic Release dry run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: npx semantic-release --dry-run
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -55,3 +55,8 @@ jobs:
             ghcr.io/raunot/plex-rewind:${{ env.NEXT_VERSION_TAG }}
           build-args: |
             NEXT_PUBLIC_VERSION_TAG=${{ env.NEXT_VERSION_TAG }}
+
+      - name: Run Semantic Release publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Run Semantic Release
+      - name: Run Semantic Release dry run
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: npx semantic-release
+        run: npx semantic-release --dry-run
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -56,3 +56,8 @@ jobs:
             ghcr.io/raunot/plex-rewind:${{ env.NEXT_VERSION_TAG }}
           build-args: |
             NEXT_PUBLIC_VERSION_TAG=${{ env.NEXT_VERSION_TAG }}
+
+      - name: Run Semantic Release publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "echo NEXT_VERSION_TAG=${nextRelease.version} >> $GITHUB_ENV"
+        "successCmd": "echo NEXT_VERSION_TAG=${nextRelease.version} >> $GITHUB_ENV"
       }
     ],
     [


### PR DESCRIPTION
We shouldn't publish releases before the build has successfully completed.