### PR TITLE
feat(dashboard): use friendly_name for users and change ranking colors

### DIFF
--- a/src/components/MediaItem/MediaItemTitle.tsx
+++ b/src/components/MediaItem/MediaItemTitle.tsx
@@ -118,7 +118,7 @@ export default function MediaItemTitle({ i, data, type, parentRef }: Props) {
           animate={controls}
           ref={titleRef}
         >
-          {type === 'users' ? data.user : data.title}
+          {type === 'users' ? data.friendly_name : data.title}
         </motion.span>
       </span>
     </h3>

--- a/src/components/MediaItem/MediaItemTitle.tsx
+++ b/src/components/MediaItem/MediaItemTitle.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { TautulliItemRow } from '@/types/tautulli'
+import clsx from 'clsx'
 import { motion, useAnimation } from 'framer-motion'
 import { debounce } from 'lodash'
 import { RefObject, useEffect, useRef } from 'react'
@@ -12,7 +13,7 @@ type Props = {
   parentRef: RefObject<HTMLDivElement>
 }
 
-const top3Colors = ['text-yellow-300', 'text-gray-300', 'text-yellow-700']
+const topColors = ['text-yellow-300', 'text-gray-300', 'text-yellow-700']
 
 export default function MediaItemTitle({ i, data, type, parentRef }: Props) {
   const titleRef = useRef<HTMLSpanElement>(null)
@@ -77,7 +78,7 @@ export default function MediaItemTitle({ i, data, type, parentRef }: Props) {
   return (
     <h3 className='mb-2 flex sm:text-xl'>
       <span className='mr-1.5 inline-flex items-baseline gap-1' ref={numberRef}>
-        <span className={`font-bold ${top3Colors[i] ?? 'text-white'}`}>
+        <span className={clsx('font-bold', topColors[i] || 'text-white')}>
           #{i + 1}{' '}
         </span>
         {i < 3 && (

--- a/src/components/MediaItem/MediaItemTitle.tsx
+++ b/src/components/MediaItem/MediaItemTitle.tsx
@@ -12,6 +12,8 @@ type Props = {
   parentRef: RefObject<HTMLDivElement>
 }
 
+const top3Colors = ['text-yellow-300', 'text-gray-300', 'text-yellow-700']
+
 export default function MediaItemTitle({ i, data, type, parentRef }: Props) {
   const titleRef = useRef<HTMLSpanElement>(null)
   const numberRef = useRef<HTMLSpanElement>(null)
@@ -75,7 +77,9 @@ export default function MediaItemTitle({ i, data, type, parentRef }: Props) {
   return (
     <h3 className='mb-2 flex sm:text-xl'>
       <span className='mr-1.5 inline-flex items-baseline gap-1' ref={numberRef}>
-        <span className='font-bold text-black'>#{i + 1} </span>
+        <span className={`font-bold ${top3Colors[i] ?? 'text-white'}`}>
+          #{i + 1}{' '}
+        </span>
         {i < 3 && (
           <svg width='16px' viewBox='0 0 300.439 300.439'>
             <path

--- a/src/types/tautulli.d.ts
+++ b/src/types/tautulli.d.ts
@@ -43,6 +43,7 @@ export type TautulliItemRow = {
   imdb_id: string | null
   user_thumb: string
   user: string
+  friendly_name: string
   requests: number
   audio_plays_count: number
   movies_plays_count: number


### PR DESCRIPTION
Also updated dashboard to make numbering easier to read. 


![grafik](https://github.com/user-attachments/assets/bc91d6fc-d45f-4d12-abd1-739d31e9be9f)
The friendly name from tautilli is used now, in place of the username. Text color is per default white and also reflects the medal color. 