### PR TITLE
feat(api): add Petio integration alongside Overseerr

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Plex Rewind application inspired by the likes of [Spotify Wrapped](https://www.spotify.com/us/wrapped) and [Tautulli](https://tautulli.com).
 
-Present [Plex](https://plex.tv) user statistics and habits in a beautiful and organized manner - as a web application application powered by [Next.js](https://nextjs.org) and [Tailwind.css](https://tailwindcss.com), using data from [Tautulli](https://tautulli.com), [Overseerr](https://overseerr.dev) and [Plex](https://plex.tv). You can also disable the Rewind functionality and just use it as an easily sharable Dashboard for your Plex users or vice versa!
+Present [Plex](https://plex.tv) user statistics and habits in a beautiful and organized manner - as a web application application powered by [Next.js](https://nextjs.org) and [Tailwind.css](https://tailwindcss.com), using data from [Tautulli](https://tautulli.com), [Overseerr](https://overseerr.dev), [Petio](https://petio.tv/) and [Plex](https://plex.tv). You can also disable the Rewind functionality and just use it as an easily sharable Dashboard for your Plex users or vice versa!
 
 ## Features
 
@@ -18,7 +18,7 @@ Present [Plex](https://plex.tv) user statistics and habits in a beautiful and or
 - 👀 Dashboard - provides an easily glanceable overview of activity on your server for all your libraries, personalized or general.
 - ⚡ Activity - see what's happening on your server in real time, enabled by [TanStack Query](https://tanstack.com/query/latest).
 - 📊 Fuelled by data from [Tautulli](https://tautulli.com) - the backbone responsible for the heavy lifting regarding statistics.
-- 🔗 Integrates with [Overseerr](https://overseerr.dev) - show request breakdowns and totals and display request buttons straight under deleted fan-favorite media items.
+- 🔗 Integrates with [Overseerr](https://overseerr.dev) or [Petio](https://petio.tv/) - show request breakdowns and totals and display request buttons straight under deleted fan-favorite media items.
 - 🔐 Log in with Plex - uses [NextAuth.js](https://next-auth.js.org) to enable secure login and session management with your Plex account.
 - 🚀 PWA support - installable on mobile devices and desktops thanks to [Serwist](https://github.com/serwist/serwist).
 - 🐳 Easy deployment - run the application in a containerized environment with [Docker](https://www.docker.com).

--- a/messages/de.json
+++ b/messages/de.json
@@ -87,6 +87,8 @@
     "save": "Speichern",
     "apiKey": "API-Schlüssel",
     "invalidApiKey": "Ungültiger API-Schlüssel!",
+    "token": "Token",
+    "invalidToken": "Ungültiges Token!",
     "unableToConnect": "Verbindung fehlgeschlagen!",
     "buyMeACoffee": "Kaffee spenden",
     "becomeASponsor": "Sponsor werden",

--- a/messages/en.json
+++ b/messages/en.json
@@ -87,6 +87,8 @@
     "save": "Save",
     "apiKey": "API key",
     "invalidApiKey": "Invalid API key!",
+    "token": "Token",
+    "invalidToken": "Invalid Token!",
     "unableToConnect": "Unable to connect!",
     "buyMeACoffee": "Buy me a coffee",
     "becomeASponsor": "Become a sponsor",

--- a/messages/et.json
+++ b/messages/et.json
@@ -87,6 +87,8 @@
     "save": "Salvesta",
     "apiKey": "API võti",
     "invalidApiKey": "Vale API võti!",
+    "token": "Märk",
+    "invalidToken": "Kehtetu märk!",
     "unableToConnect": "Ühenduse loomine ebaõnnestus!",
     "buyMeACoffee": "Osta mulle kohvi",
     "becomeASponsor": "Hakka sponsoriks",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -87,6 +87,8 @@
     "save": "Enregistrer",
     "apiKey": "Clé API",
     "invalidApiKey": "Clé API invalide !",
+    "token": "Jeton",
+    "invalidToken": "Jeton invalide!",
     "unableToConnect": "Impossible de se connecter !",
     "buyMeACoffee": "Offrez-moi un café",
     "becomeASponsor": "Devenir sponsor",

--- a/src/app/dashboard/users/page.tsx
+++ b/src/app/dashboard/users/page.tsx
@@ -2,6 +2,7 @@ import { authOptions } from '@/lib/auth'
 import { DashboardSearchParams } from '@/types/dashboard'
 import { Settings } from '@/types/settings'
 import { fetchOverseerrStats } from '@/utils/fetchOverseerr'
+import { fetchPetioTotalRequests } from '@/utils/fetchPetio'
 import fetchTautulli, { getUsersCount } from '@/utils/fetchTautulli'
 import {
   secondsToTime,
@@ -53,6 +54,8 @@ async function getTotalDuration(
 async function getTotalRequests(period: string, settings: Settings) {
   const isOverseerrActive =
     settings.connection.overseerrUrl && settings.connection.overseerrApiKey
+  const isPetioActive =
+    settings.connection.petioUrl && settings.connection.petioToken
 
   if (
     settings.dashboard.activeTotalStatistics.includes('requests') &&
@@ -61,6 +64,17 @@ async function getTotalRequests(period: string, settings: Settings) {
     const requests = await fetchOverseerrStats('request', period)
 
     return requests.length.toString()
+  }
+
+  if (
+    settings.dashboard.activeTotalStatistics.includes('requests') &&
+    isPetioActive
+  ) {
+    const stats = await fetchPetioTotalRequests(period)
+
+    if (!stats) return undefined
+
+    return String(stats.total)
   }
 
   return undefined

--- a/src/app/rewind/page.tsx
+++ b/src/app/rewind/page.tsx
@@ -5,11 +5,11 @@ import fetchTautulli, { getLibraries, getServerId } from '@/utils/fetchTautulli'
 import { secondsToTime } from '@/utils/formatting'
 import {
   getLibrariesTotalDuration,
+  getlibrariesTotalSize,
   getRequestsTotals,
   getTopMediaItems,
   getTopMediaStats,
   getUserTotalDuration,
-  getlibrariesTotalSize,
 } from '@/utils/getRewind'
 import getSettings from '@/utils/getSettings'
 import getUsersTop from '@/utils/getUsersTop'
@@ -110,11 +110,11 @@ async function RewindContent({ userId }: { userId?: string }) {
   }
   const isOverseerrActive =
     settings.connection.overseerrUrl && settings.connection.overseerrApiKey
+  const isPetioActive =
+    settings.connection.petioUrl && settings.connection.petioToken
 
-  if (isOverseerrActive) {
-    const requestTotals = await getRequestsTotals(user.id)
-
-    userRewind.requests = requestTotals
+  if (isOverseerrActive || isPetioActive) {
+    userRewind.requests = await getRequestsTotals(user.id)
   }
 
   return (

--- a/src/app/settings/connection/_components/ConnectionSettingsForm.tsx
+++ b/src/app/settings/connection/_components/ConnectionSettingsForm.tsx
@@ -121,6 +121,36 @@ export default function ConnectionSettingsForm({ settings }: Props) {
           </span>
         </label>
       </section>
+      <section className='group-settings group'>
+        {/* eslint-disable-next-line react/jsx-no-literals */}
+        <h2 className='heading-settings'>Petio</h2>
+        <label className='input-wrapper'>
+          <input
+            key={`petio-url-${connectionSettings.petioUrl}`}
+            type='url'
+            className='input'
+            placeholder='http://192.168.1.2:5055'
+            name='petioUrl'
+            defaultValue={connectionSettings.petioUrl}
+          />
+          <span className='label'>
+            {/* eslint-disable-next-line react/jsx-no-literals */}
+            <span className='label-wrapper'>URL</span>
+          </span>
+        </label>
+        <label className='input-wrapper'>
+          <input
+            key={`petio-token-${connectionSettings.petioToken}`}
+            type='password'
+            className='input'
+            name='petioToken'
+            defaultValue={connectionSettings.petioToken}
+          />
+          <span className='label'>
+            <span className='label-wrapper'>{t('token')}</span>
+          </span>
+        </label>
+      </section>
     </SettingsForm>
   )
 }

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -9,6 +9,8 @@ export type ConnectionSettings = {
   tautulliApiKey: string
   overseerrUrl?: string
   overseerrApiKey?: string
+  petioUrl?: string
+  petioToken?: string
   plexUrl: string
   complete: boolean
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -43,6 +43,8 @@ export const DEFAULT_SETTINGS: Settings = {
     plexUrl: '',
     overseerrUrl: '',
     overseerrApiKey: '',
+    petioUrl: '',
+    petioToken: '',
     complete: false,
   },
   general: {

--- a/src/utils/fetchPetio.ts
+++ b/src/utils/fetchPetio.ts
@@ -1,0 +1,276 @@
+'use server'
+
+import getSettings from './getSettings'
+
+type PetioResponse<T> = {
+  results?: T[]
+  requests?: T[]
+}
+
+type PetioUser = {
+  id: string | number
+}
+
+type PetioRequestItem = {
+  timeStamp: string | number
+  type: string
+  users: string[]
+}
+
+type PetioRequestStats = {
+  total: number
+  movies: number
+  shows: number
+  user: number
+}
+
+function unwrapResults<T>(res: PetioResponse<T> | T[] | null): T[] {
+  if (!res) return []
+
+  return Array.isArray(res) ? res : (res.results ?? [])
+}
+
+function toDate(ts: unknown): Date | null {
+  if (ts == null) return null
+
+  if (typeof ts === 'number') {
+    const ms = ts < 1e12 ? ts * 1000 : ts
+    const d = new Date(ms)
+
+    return Number.isNaN(d.getTime()) ? null : d
+  }
+
+  if (typeof ts === 'string') {
+    const trimmed = ts.trim()
+    const maybeNum = Number(trimmed)
+
+    if (!Number.isNaN(maybeNum)) {
+      const ms = maybeNum < 1e12 ? maybeNum * 1000 : maybeNum
+      const d = new Date(ms)
+
+      return Number.isNaN(d.getTime()) ? null : d
+    }
+
+    const d = new Date(trimmed)
+
+    return Number.isNaN(d.getTime()) ? null : d
+  }
+
+  return null
+}
+
+export default async function fetchPetio<T>(
+  endpoint: string,
+  additionalParams?: Record<string, string>,
+): Promise<T | null> {
+  const settings = getSettings()
+  const petioUrl = settings.connection.petioUrl
+  const petioToken = settings.connection.petioToken
+
+  if (!petioUrl) {
+    console.error('[PETIO] - URL is not configured! Skipping request.')
+
+    return null
+  }
+
+  if (!petioToken) {
+    console.error('[PETIO] - API key is not configured! Skipping request.')
+
+    return null
+  }
+
+  const queryParams = new URLSearchParams(additionalParams)
+  const apiUrl = `${petioUrl}/api/${endpoint}?${queryParams.toString()}`
+
+  try {
+    const res = await fetch(apiUrl, {
+      headers: {
+        Authorization: 'Bearer ' + petioToken,
+      },
+    })
+
+    if (!res.ok) {
+      console.error(
+        `[PETIO] - API request failed! The endpoint was '${endpoint}'.\n`,
+        res.status,
+        res.statusText,
+      )
+
+      return null
+    }
+
+    return res.json()
+  } catch (error) {
+    console.error(
+      `[PETIO] - Error fetching from API! The endpoint was '${endpoint}'.\n`,
+      error,
+    )
+
+    return null
+  }
+}
+
+export async function fetchPetioStats(
+  req: string,
+  startDate: string,
+  endDate?: string,
+): Promise<PetioRequestItem[]> {
+  const data = await fetchPetio<
+    PetioResponse<PetioRequestItem> | PetioRequestItem[]
+  >(req)
+  const itemsFromResponse = Array.isArray(data)
+    ? data
+    : (data?.results ?? data?.requests ?? [])
+
+  if (itemsFromResponse.length === 0) {
+    console.error('[PETIO] - No requests data found!')
+
+    return []
+  }
+
+  const startDateObj = toDate(startDate) ?? new Date(startDate)
+  const endDateObj = endDate
+    ? (toDate(endDate) ?? new Date(endDate))
+    : new Date()
+  const filteredRequests = itemsFromResponse.filter((request) => {
+    const requestDate = toDate(request.timeStamp)
+
+    if (!requestDate) return false
+
+    return requestDate >= startDateObj && requestDate <= endDateObj
+  })
+
+  return filteredRequests
+}
+
+export async function fetchPetioUserId(plexId: string): Promise<number | null> {
+  const response = await fetchPetio<PetioResponse<PetioUser>>('user/all')
+  const users: PetioUser[] = Array.isArray(response)
+    ? response
+    : (response?.results ?? [])
+
+  if (users.length === 0) {
+    console.error('[PETIO] - No user data found!')
+
+    return null
+  }
+
+  const match = users.find((u) => String(u.id) === String(plexId))
+
+  if (!match) {
+    console.error(`[PETIO] - No matching user found for plexId ${plexId}!`)
+
+    return null
+  }
+
+  const numericId = Number(match.id)
+
+  return Number.isFinite(numericId) ? numericId : null
+}
+
+export async function fetchPetioTotalRequests(
+  startDate: string,
+  endDate?: string,
+  userId?: string | number,
+): Promise<PetioRequestStats | undefined> {
+  const toArray = <T>(data: unknown, keys: string[]): T[] => {
+    if (Array.isArray(data)) return data as T[]
+
+    if (data && typeof data === 'object') {
+      for (const k of keys) {
+        const v = (data as Record<string, unknown>)[k]
+
+        if (Array.isArray(v)) return v as T[]
+      }
+    }
+
+    return []
+  }
+
+  if (userId) {
+    const response = await fetchPetio<
+      PetioResponse<PetioRequestItem> | PetioRequestItem[]
+    >(`request/archive/${userId}`)
+    const requests = toArray<PetioRequestItem>(response, [
+      'results',
+      'requests',
+    ])
+
+    if (!requests.length) {
+      return {
+        total: 0,
+        movies: 0,
+        shows: 0,
+        user: 0,
+      }
+    }
+
+    const start = new Date(startDate)
+    const end = endDate ? new Date(endDate) : new Date()
+    const filtered = requests.filter((r) => {
+      const date = toDate(r.timeStamp)
+
+      return date !== null && date >= start && date <= end
+    })
+    const normType = (t: unknown) =>
+      typeof t === 'string' ? t.toLowerCase() : ''
+    const movies = filtered.filter((r) => normType(r.type) === 'movie').length
+    const shows = filtered.filter((r) =>
+      ['tv', 'show', 'series'].includes(normType(r.type)),
+    ).length
+
+    return {
+      total: filtered.length,
+      movies,
+      shows,
+      user: filtered.length,
+    }
+  }
+
+  const rawUsers = await fetchPetio<PetioResponse<PetioUser> | PetioUser[]>(
+    'user/all',
+  )
+  const users = unwrapResults<PetioUser>(rawUsers)
+
+  if (!users.length) {
+    console.error('[PETIO] - No users found!')
+
+    return {
+      total: 0,
+      movies: 0,
+      shows: 0,
+      user: 0,
+    }
+  }
+
+  const responses = await Promise.all(
+    users.map((user) =>
+      fetchPetio<PetioResponse<PetioRequestItem> | PetioRequestItem[]>(
+        `request/archive/${user.id}`,
+      ),
+    ),
+  )
+  const allRequests = responses.flatMap((res) =>
+    toArray<PetioRequestItem>(res, ['results', 'requests']),
+  )
+  const start = new Date(startDate)
+  const end = endDate ? new Date(endDate) : new Date()
+  const filtered = allRequests.filter((r) => {
+    const date = toDate(r.timeStamp)
+
+    return date !== null && date >= start && date <= end
+  })
+  const normType = (t: unknown) =>
+    typeof t === 'string' ? t.toLowerCase() : ''
+  const movies = filtered.filter((r) => normType(r.type) === 'movie').length
+  const shows = filtered.filter((r) =>
+    ['tv', 'show', 'series'].includes(normType(r.type)),
+  ).length
+
+  return {
+    total: filtered.length,
+    movies,
+    shows,
+    user: filtered.length,
+  }
+}


### PR DESCRIPTION
### What & why
Adds Petio support alongside Overseerr for request statistics.

### Changes
- Extended functionality to support Petio API.
- Updated connection settings form with Petio URL + token fields.
- Added utility functions for Petio API requests.
- Added fallback logic in request statistics handling.
- Updated translations for new settings fields.

### How to test
1. Go to Settings → Connections.
2. Add Petio URL and token.
3. Verify request statistics are fetched correctly.
4. Check fallback to Overseerr still works.