### PR TITLE
fix(#359): use internal loopback for middleware settings fetch

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,8 +28,8 @@ async function fetchJson<T>(url: string): Promise<T | null> {
     const contentType = res.headers.get('content-type') || ''
 
     if (!contentType.includes('application/json')) {
-      console.error(
-        `[PROXY] - Expected JSON from ${url} but got "${contentType}". Is a reverse proxy intercepting internal requests?`,
+      console.warn(
+        `[PROXY] - Expected JSON from ${url} but received "${contentType}". Skipping settings check for this request.`,
       )
 
       return null

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,4 @@
+import { Settings } from '@/types/settings'
 import { withAuth } from 'next-auth/middleware'
 import { NextResponse } from 'next/server'
 import {
@@ -6,58 +7,89 @@ import {
   isPostUpdateMissingSettings,
 } from './utils/helpers'
 
+// The middleware reads settings from the app's own API. Fetching the public
+// URL (NEXT_PUBLIC_SITE_URL) makes the container round-trip back through any
+// reverse proxy (e.g. Cloudflare tunnel), which can return an HTML challenge or
+// error page with a 200 status and break JSON parsing (see issue #359). Always
+// hit the server over the internal loopback address instead. The Docker image
+// sets PORT=8383; locally Next.js defaults to 3000 when PORT is unset.
+const INTERNAL_BASE_URL = `http://127.0.0.1:${process.env.PORT || '3000'}`
+
+// Safely parse a fetch response as JSON. A reverse proxy can return HTML with a
+// 200 status, so guard against non-JSON bodies instead of throwing.
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url)
+
+    if (!res.ok) {
+      return null
+    }
+
+    const contentType = res.headers.get('content-type') || ''
+
+    if (!contentType.includes('application/json')) {
+      console.error(
+        `[PROXY] - Expected JSON from ${url} but got "${contentType}". Is a reverse proxy intercepting internal requests?`,
+      )
+
+      return null
+    }
+
+    return await res.json()
+  } catch (error) {
+    console.error(`[PROXY] - Failed to fetch ${url}!`, error)
+
+    return null
+  }
+}
+
 export default withAuth(
   async function proxy(req) {
     const { pathname } = req.nextUrl
-    const settingsRes = await fetch(
-      `${process.env.NEXT_PUBLIC_SITE_URL}/api/settings`,
+    const settings = await fetchJson<Settings>(
+      `${INTERNAL_BASE_URL}/api/settings`,
     )
-    const settings = settingsRes.ok ? await settingsRes.json() : null
-    const missingSettingRes = await fetch(
-      `${process.env.NEXT_PUBLIC_SITE_URL}/api/missing-setting`,
+    const missingSetting = await fetchJson<string>(
+      `${INTERNAL_BASE_URL}/api/missing-setting`,
     )
 
-    if (missingSettingRes.ok && settings) {
-      const missingSetting = await missingSettingRes.json()
+    if (missingSetting && settings) {
+      const isSettingsPage = pathname.includes('settings')
+      const isAdmin = req.nextauth?.token?.isAdmin
+      const isInitialSetupMode = isInitialSetup(settings)
+      const isPostUpdateMode = isPostUpdateMissingSettings(settings)
 
-      if (missingSetting) {
-        const isSettingsPage = pathname.includes('settings')
-        const isAdmin = req.nextauth?.token?.isAdmin
-        const isInitialSetupMode = isInitialSetup(settings)
-        const isPostUpdateMode = isPostUpdateMissingSettings(settings)
+      // During initial setup, allow access to settings pages for any user (including unauthenticated)
+      if (isInitialSetupMode && isSettingsPage) {
+        return NextResponse.next()
+      }
 
-        // During initial setup, allow access to settings pages for any user (including unauthenticated)
-        if (isInitialSetupMode && isSettingsPage) {
-          return NextResponse.next()
-        }
-
-        // For post-update missing settings, only allow admin access
-        if (isPostUpdateMode && !isAdmin) {
-          if (pathname !== '/') {
-            return NextResponse.redirect(
-              new URL('/', process.env.NEXT_PUBLIC_SITE_URL),
-            )
-          }
-
-          return NextResponse.next()
-        }
-
-        // Handle redirects for missing settings
-        let redirectPage = getSettingsPage(missingSetting)
-
-        if (missingSetting.startsWith('connection')) {
-          redirectPage = getSettingsPage('connection')
-        }
-
-        if (
-          redirectPage &&
-          pathname !== redirectPage &&
-          !pathname.includes('settings')
-        ) {
+      // For post-update missing settings, only allow admin access
+      if (isPostUpdateMode && !isAdmin) {
+        if (pathname !== '/') {
           return NextResponse.redirect(
-            new URL(redirectPage, process.env.NEXT_PUBLIC_SITE_URL),
+            new URL('/', process.env.NEXT_PUBLIC_SITE_URL),
           )
         }
+
+        return NextResponse.next()
+      }
+
+      // Handle redirects for missing settings
+      let redirectPage = getSettingsPage(missingSetting)
+
+      if (missingSetting.startsWith('connection')) {
+        redirectPage = getSettingsPage('connection')
+      }
+
+      if (
+        redirectPage &&
+        pathname !== redirectPage &&
+        !pathname.includes('settings')
+      ) {
+        return NextResponse.redirect(
+          new URL(redirectPage, process.env.NEXT_PUBLIC_SITE_URL),
+        )
       }
     }
 


### PR DESCRIPTION
Fixes #359.

## Problem

Behind a reverse proxy (the reporter uses a Cloudflare tunnel) the app returns a 500 with:

```
SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
    at JSON.parse (<anonymous>)
    at async ...callbacks.authorized...
```

The throw is in the NextAuth middleware (`src/proxy.ts`), not the Plex login flow — `withAuth` wraps the middleware under the `authorized` callback frame, which is why the minified trace points there.

The middleware fetched the app's **own public URL** (`NEXT_PUBLIC_SITE_URL`) to read settings that live on the local filesystem:

```ts
const settingsRes = await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/settings`)
const settings = settingsRes.ok ? await settingsRes.json() : null
```

That request round-trips out through the reverse proxy and back into the container. When the proxy returns an HTML page with a **200 status** (a Cloudflare Access challenge/login page, or an error interstitial), `res.ok` is `true`, so `.json()` runs `JSON.parse("<!DOCTYPE html>...")` and crashes the whole app.

## Fix

- Fetch the settings APIs over the **internal loopback address** (`http://127.0.0.1:${PORT}`) so the request never leaves the container and can't be intercepted by a proxy. The Docker image sets `PORT=8383`; local dev falls back to Next's default `3000`.
- Add a `fetchJson` helper that guards parsing: checks `res.ok` **and** `content-type: application/json`, and wraps everything in try/catch, so a non-JSON response degrades to `null` instead of 500-ing.

Browser-facing redirects still use `NEXT_PUBLIC_SITE_URL`, as they should.