### PR TITLE
feat(rewind): playback habits

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -249,6 +249,10 @@
       "favorite": "Dein Lieblingsfilm war",
       "noData": "Du hast keine <movies>Filme</movies> auf <plex>{serverName}</plex> gesehen <emoji>😵‍💫</emoji>"
     },
+    "Habits": {
+      "day": "Dein liebster Tag zum Schauen war <day>{dayValue}</day>",
+      "hour": "Und am häufigsten hast du gegen <hour>{hourValue}</hour> Play gedrückt <emoji>{emojiValue}</emoji>"
+    },
     "Goodbye": {
       "thanks": "Vielen Dank, dass du dir deinen <plex>{serverName} Rewind</plex> angeschaut hast, <user>{userValue}!</user>",
       "sorry": "Es tut uns leid, dass du keine Inhalte für dich gefunden hast. Mehr Erfolg beim nächsten Mal!",

--- a/messages/en.json
+++ b/messages/en.json
@@ -251,7 +251,7 @@
     },
     "Habits": {
       "day": "Your favorite day to watch was <day>{dayValue}</day>",
-      "hour": "And you pressed play most around <hour>{hourValue}</hour> <emoji>{emojiValue}</emoji>"
+      "hour": "And you pressed play most often around <hour>{hourValue}</hour> <emoji>{emojiValue}</emoji>"
     },
     "Goodbye": {
       "thanks": "Thanks for tuning into your <plex>{serverName} Rewind</plex>, <user>{userValue}!</user>",

--- a/messages/en.json
+++ b/messages/en.json
@@ -249,6 +249,10 @@
       "favorite": "Your favorite was",
       "noData": "You didn't watch any <movies>Movies</movies> on <plex>{serverName}</plex> <emoji>😵‍💫</emoji>"
     },
+    "Habits": {
+      "day": "Your favorite day to watch was <day>{dayValue}</day>",
+      "hour": "And you pressed play most around <hour>{hourValue}</hour> <emoji>{emojiValue}</emoji>"
+    },
     "Goodbye": {
       "thanks": "Thanks for tuning into your <plex>{serverName} Rewind</plex>, <user>{userValue}!</user>",
       "sorry": "Sorry you couldn't find any content to watch or listen to this time around. Better luck next time!",

--- a/messages/et.json
+++ b/messages/et.json
@@ -249,6 +249,10 @@
       "favorite": "Sinu lemmik oli",
       "noData": "Sa ei vaadanud ühtegi <movies>Filmi</movies> <plex>{serverName}'ist</plex> <emoji>😵‍💫</emoji>"
     },
+    "Habits": {
+      "day": "Sinu lemmik vaatamispäev oli <day>{dayValue}</day>",
+      "hour": "Ja kõige sagedamini panid mängima umbes kell <hour>{hourValue}</hour> <emoji>{emojiValue}</emoji>"
+    },
     "Goodbye": {
       "thanks": "Tänan, et vaatasid oma <plex>{serverName} Rewind'i</plex>, <user>{userValue}!</user>",
       "sorry": "Kahju, et sa ei leidnud seekord sisu mida vaadata või kuulata. Loodame, et järgmisel korral läheb paremini!",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -249,6 +249,10 @@
       "favorite": "Votre favori était",
       "noData": "Vous n'avez regardé aucun <movies>Film</movies> sur <plex>{serverName}</plex> <emoji>😵‍💫</emoji>"
     },
+    "Habits": {
+      "day": "Votre jour préféré pour regarder était le <day>{dayValue}</day>",
+      "hour": "Et vous lanciez la lecture surtout vers <hour>{hourValue}</hour> <emoji>{emojiValue}</emoji>"
+    },
     "Goodbye": {
       "thanks": "Merci d'avoir suivi votre <plex>{serverName} Rewind</plex>, <user>{userValue} !</user>",
       "sorry": "Désolé que vous n'ayez pas trouvé de contenu à regarder ou à écouter cette fois-ci. Bonne chance pour la prochaine fois !",

--- a/src/app/rewind/_components/RewindBarChart.tsx
+++ b/src/app/rewind/_components/RewindBarChart.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import clsx from 'clsx'
+import { motion } from 'motion/react'
+
+type Props = {
+  data: number[]
+  peakIndex: number | null
+  labels?: (string | null)[]
+  className?: string
+}
+
+// Rounds the axis up to a "nice" maximum and returns evenly spaced ticks, so
+// the gridlines land on readable values (0, 20, 40, …) rather than the raw max.
+function getScale(maxValue: number) {
+  const rawStep = maxValue / 4
+  const magnitude = 10 ** Math.floor(Math.log10(rawStep))
+  const normalized = rawStep / magnitude
+  const niceStep =
+    (normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10) *
+    magnitude
+  const step = Math.max(Math.round(niceStep), 1)
+  const niceMax = Math.ceil(maxValue / step) * step
+  const ticks: number[] = []
+
+  for (let tick = 0; tick <= niceMax; tick += step) {
+    ticks.push(tick)
+  }
+
+  return { niceMax, ticks }
+}
+
+// Labels are centered on their bar, but on dense charts (the 24-hour view) a
+// label near an edge is clamped to the plot bounds — anchored by its left edge
+// at the start and its right edge at the end — so it can never be clipped.
+function labelTransform(index: number, count: number) {
+  if (count <= 12) {
+    return 'translateX(-50%)'
+  }
+
+  const position = (index + 0.5) / count
+
+  if (position <= 0.12) {
+    return 'translateX(0)'
+  }
+
+  if (position >= 0.88) {
+    return 'translateX(-100%)'
+  }
+
+  return 'translateX(-50%)'
+}
+
+export default function RewindBarChart({
+  data,
+  peakIndex,
+  labels,
+  className,
+}: Props) {
+  const { niceMax, ticks } = getScale(Math.max(...data, 1))
+
+  return (
+    <div className={clsx('w-full not-italic', className)}>
+      <div className='flex'>
+        <div className='relative mr-2 h-56 w-8 shrink-0 sm:h-40'>
+          {ticks.map((tick) => (
+            <span
+              key={tick}
+              className='absolute right-0 -translate-y-1/2 text-xs text-neutral-500 tabular-nums'
+              style={{ bottom: `${(tick / niceMax) * 100}%` }}
+            >
+              {tick}
+            </span>
+          ))}
+        </div>
+
+        <div className='relative flex-1'>
+          {ticks.map((tick) => (
+            <span
+              key={tick}
+              className='absolute inset-x-0 border-t border-white/10'
+              style={{ bottom: `${(tick / niceMax) * 100}%` }}
+            />
+          ))}
+
+          <div className='relative flex h-56 items-end gap-[2px] sm:h-40 sm:gap-1'>
+            {data.map((value, index) => {
+              const isPeak = index === peakIndex
+              const heightPercentage =
+                value > 0 ? Math.max((value / niceMax) * 100, 2) : 0
+
+              return (
+                <div
+                  key={index}
+                  className='flex h-full min-w-0 flex-1 items-end'
+                >
+                  <motion.div
+                    className={clsx(
+                      'w-full origin-bottom rounded-t-sm',
+                      isPeak
+                        ? 'bg-linear-to-t from-yellow-600 to-yellow-300'
+                        : 'bg-linear-to-t from-blue-600 to-teal-400',
+                    )}
+                    style={{ height: `${heightPercentage}%` }}
+                    initial={{ scaleY: 0 }}
+                    animate={{ scaleY: 1 }}
+                    transition={{
+                      delay: index * 0.025,
+                      duration: 0.5,
+                      ease: 'easeOut',
+                    }}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      </div>
+
+      {labels && (
+        <div className='mt-2 flex'>
+          <div className='mr-2 w-8 shrink-0' aria-hidden />
+          <div className='relative h-4 flex-1'>
+            {labels.map((label, index) =>
+              label ? (
+                <span
+                  key={index}
+                  className={clsx(
+                    'absolute top-0 text-xs whitespace-nowrap',
+                    index === peakIndex
+                      ? 'gradient-plex font-semibold'
+                      : 'text-neutral-400',
+                  )}
+                  style={{
+                    left: `${((index + 0.5) / labels.length) * 100}%`,
+                    transform: labelTransform(index, labels.length),
+                  }}
+                >
+                  {label}
+                </span>
+              ) : null,
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/rewind/_components/RewindStories.tsx
+++ b/src/app/rewind/_components/RewindStories.tsx
@@ -7,6 +7,8 @@ import Stories from './Stories'
 import StoryAudio from './Stories/Audio'
 import StoryAudioTop from './Stories/AudioTop'
 import StoryGoodbye from './Stories/Goodbye'
+import StoryHabitsDay from './Stories/HabitsDay'
+import StoryHabitsHour from './Stories/HabitsHour'
 import StoryLibraries from './Stories/Libraries'
 import StoryMovies from './Stories/Movies'
 import StoryMoviesTop from './Stories/MoviesTop'
@@ -94,6 +96,12 @@ export default function RewindStories({ userRewind, settings }: Props) {
       : []),
     ...(userRewind.audio.top.length > 1 && hasAudioLibraries
       ? [createStory(StoryAudioTop, 8000)]
+      : []),
+    ...(userRewind.habits.peakDayIndex !== null
+      ? [createStory(StoryHabitsDay, 10000)]
+      : []),
+    ...(userRewind.habits.peakHour !== null
+      ? [createStory(StoryHabitsHour, 10000)]
       : []),
     createStory(StoryGoodbye, 11000),
   ]

--- a/src/app/rewind/_components/Stories/HabitsDay.tsx
+++ b/src/app/rewind/_components/Stories/HabitsDay.tsx
@@ -1,0 +1,50 @@
+import { RewindStory } from '@/types/rewind'
+import { CalendarDaysIcon } from '@heroicons/react/24/outline'
+import { useLocale, useTranslations } from 'next-intl'
+import RewindBarChart from '../RewindBarChart'
+import RewindStat from '../RewindStat'
+
+// 2024-01-07 is a Sunday, so adding the index lands on the matching weekday and
+// lets Intl produce a localized day name without hardcoding translations.
+function weekday(index: number, locale: string, style: 'long' | 'short') {
+  return new Intl.DateTimeFormat(locale, {
+    weekday: style,
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(2024, 0, 7 + index)))
+}
+
+export default function StoryHabitsDay({ userRewind, isPaused }: RewindStory) {
+  const t = useTranslations('Rewind.Habits')
+  const locale = useLocale()
+  const { peakDayIndex, daily } = userRewind.habits
+
+  if (peakDayIndex === null) {
+    return null
+  }
+
+  const labels = Array.from({ length: 7 }, (_, index) =>
+    weekday(index, locale, 'short'),
+  )
+
+  return (
+    <>
+      <RewindStat isPaused={isPaused} scaleDelay={3}>
+        <p>
+          {t.rich('day', {
+            dayValue: weekday(peakDayIndex, locale, 'long'),
+            day: (chunks) => (
+              <span className='rewind-cat'>
+                {chunks}
+                <CalendarDaysIcon />
+              </span>
+            ),
+          })}
+        </p>
+      </RewindStat>
+
+      <RewindStat isPaused={isPaused} renderDelay={3} noScale className='pt-4'>
+        <RewindBarChart data={daily} labels={labels} peakIndex={peakDayIndex} />
+      </RewindStat>
+    </>
+  )
+}

--- a/src/app/rewind/_components/Stories/HabitsHour.tsx
+++ b/src/app/rewind/_components/Stories/HabitsHour.tsx
@@ -1,0 +1,76 @@
+import { RewindStory } from '@/types/rewind'
+import { ClockIcon } from '@heroicons/react/24/outline'
+import { useLocale, useTranslations } from 'next-intl'
+import RewindBarChart from '../RewindBarChart'
+import RewindStat from '../RewindStat'
+
+// Context hours for the axis (edges are skipped so labels stay in bounds). The
+// peak is always labelled on top of these; any anchor too close to it is
+// dropped so the two labels don't overlap.
+const ANCHOR_HOURS = [6, 12, 18]
+const MIN_LABEL_GAP = 3
+
+function formatHour(hour: number, locale: string) {
+  return new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(2024, 0, 1, hour)))
+}
+
+function hourEmoji(hour: number) {
+  if (hour >= 5 && hour < 12) {
+    return '☀️'
+  }
+
+  if (hour >= 12 && hour < 18) {
+    return '🌤️'
+  }
+
+  return '🌙'
+}
+
+export default function StoryHabitsHour({ userRewind, isPaused }: RewindStory) {
+  const t = useTranslations('Rewind.Habits')
+  const locale = useLocale()
+  const { peakHour, hourly } = userRewind.habits
+
+  if (peakHour === null) {
+    return null
+  }
+
+  const labelledHours = new Set([peakHour])
+
+  for (const anchor of ANCHOR_HOURS) {
+    if (Math.abs(anchor - peakHour) >= MIN_LABEL_GAP) {
+      labelledHours.add(anchor)
+    }
+  }
+
+  const labels = Array.from({ length: 24 }, (_, hour) =>
+    labelledHours.has(hour) ? formatHour(hour, locale) : null,
+  )
+
+  return (
+    <>
+      <RewindStat isPaused={isPaused} scaleDelay={3}>
+        <p>
+          {t.rich('hour', {
+            hourValue: formatHour(peakHour, locale),
+            emojiValue: hourEmoji(peakHour),
+            hour: (chunks) => (
+              <span className='rewind-cat'>
+                {chunks}
+                <ClockIcon />
+              </span>
+            ),
+            emoji: (chunks) => <span className='not-italic'>{chunks}</span>,
+          })}
+        </p>
+      </RewindStat>
+
+      <RewindStat isPaused={isPaused} renderDelay={3} noScale className='pt-4'>
+        <RewindBarChart data={hourly} labels={labels} peakIndex={peakHour} />
+      </RewindStat>
+    </>
+  )
+}

--- a/src/app/rewind/page.tsx
+++ b/src/app/rewind/page.tsx
@@ -5,6 +5,7 @@ import fetchTautulli, { getLibraries, getServerId } from '@/utils/fetchTautulli'
 import { secondsToTime } from '@/utils/formatting'
 import {
   getLibrariesTotalDuration,
+  getPlaybackHabits,
   getRequestsTotals,
   getTopMediaItems,
   getTopMediaStats,
@@ -70,6 +71,7 @@ async function RewindContent({ userId }: { userId?: string }) {
     librariesTotalDuration,
     serverId,
     usersTop,
+    habits,
   ] = await Promise.all([
     getTopMediaItems(user.id, libraries),
     getTopMediaStats(user.id, libraries),
@@ -78,6 +80,7 @@ async function RewindContent({ userId }: { userId?: string }) {
     getLibrariesTotalDuration(libraries),
     getServerId(),
     getUsersTop(user.id, startDate, 0, endDate),
+    getPlaybackHabits(user.id),
   ])
   const userRewind: UserRewind = {
     duration: {
@@ -103,6 +106,7 @@ async function RewindContent({ userId }: { userId?: string }) {
       count: topMediaStats.audio.count,
       duration: topMediaStats.audio.duration,
     },
+    habits: habits,
     libraries: libraries,
     libraries_total_size: librariesTotalSize,
     server_id: serverId,

--- a/src/types/rewind.d.ts
+++ b/src/types/rewind.d.ts
@@ -20,6 +20,13 @@ export type UserRewind = {
   shows: LibraryRewind
   movies: LibraryRewind
   audio: LibraryRewind
+  habits: {
+    peakHour: number | null
+    peakDayIndex: number | null
+    totalPlays: number
+    hourly: number[]
+    daily: number[]
+  }
   duration: {
     user: string
     user_percentage: string

--- a/src/types/tautulli.d.ts
+++ b/src/types/tautulli.d.ts
@@ -30,6 +30,14 @@ export type TautulliItem = {
   stat_id: string
 }
 
+export type TautulliGraph = {
+  categories: string[]
+  series: {
+    name: string
+    data: number[]
+  }[]
+}
+
 export type TautulliItemRow = {
   title: string
   year: number | null

--- a/src/utils/getRewind.ts
+++ b/src/utils/getRewind.ts
@@ -1,4 +1,5 @@
 import {
+  TautulliGraph,
   TautulliItem,
   TautulliItemRow,
   TautulliLibrary,
@@ -220,6 +221,90 @@ export async function getTopMediaItems(
   combinedResult.audio = sortAndSlice(combinedResult.audio)
 
   return combinedResult
+}
+
+// Maps Tautulli's English day-of-week labels to a fixed index (0 = Sunday) so
+// the peak day is resolved from the actual label rather than its array
+// position, which shifts with Tautulli's `week_start_monday` setting.
+const DAY_NAME_TO_INDEX: Record<string, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+}
+
+// Sums every series ('TV', 'Movies', 'Music', ...) into a single per-category
+// total, keeping the same order as `categories`.
+function sumGraphSeries(graph?: TautulliGraph): number[] {
+  if (!graph?.categories?.length) {
+    return []
+  }
+
+  return graph.categories.map((_, index) =>
+    graph.series.reduce((sum, serie) => sum + (serie.data[index] ?? 0), 0),
+  )
+}
+
+function peakIndex(totals: number[]): number | null {
+  if (!totals.length) {
+    return null
+  }
+
+  let maxIndex = 0
+
+  for (let i = 1; i < totals.length; i++) {
+    if (totals[i] > totals[maxIndex]) {
+      maxIndex = i
+    }
+  }
+
+  return totals[maxIndex] > 0 ? maxIndex : null
+}
+
+export async function getPlaybackHabits(userId: string) {
+  const { startDate, endDate } = getRewindDateRange(getSettings())
+  // Like getTopMediaItems, the graph endpoints only accept a `time_range` in
+  // days (last N days), not before/after — so a custom range is approximated
+  // by its length, consistent with the rest of the rewind.
+  const time_range = daysBetween(startDate, endDate)
+  const [hourRes, dayRes] = await Promise.all([
+    fetchTautulli<TautulliGraph>('get_plays_by_hourofday', {
+      user_id: userId,
+      time_range,
+      y_axis: 'plays',
+    }),
+    fetchTautulli<TautulliGraph>('get_plays_by_dayofweek', {
+      user_id: userId,
+      time_range,
+      y_axis: 'plays',
+    }),
+  ])
+  // `hourly` already lines up with the hour (categories are '00'..'23').
+  const hourly = sumGraphSeries(hourRes?.response?.data)
+  const dayData = dayRes?.response?.data
+  const dayTotals = sumGraphSeries(dayData)
+  // Normalize day-of-week into a fixed Sunday-first order resolved from
+  // Tautulli's English labels, whose array order shifts with week_start_monday.
+  const daily = Array<number>(7).fill(0)
+
+  dayData?.categories.forEach((name, position) => {
+    const index = DAY_NAME_TO_INDEX[name]
+
+    if (index !== undefined) {
+      daily[index] = dayTotals[position]
+    }
+  })
+
+  return {
+    peakHour: peakIndex(hourly),
+    peakDayIndex: peakIndex(daily),
+    totalPlays: hourly.reduce((sum, plays) => sum + plays, 0),
+    hourly,
+    daily,
+  }
 }
 
 export async function getRequestsTotals(userId: string) {

--- a/src/utils/getRewind.ts
+++ b/src/utils/getRewind.ts
@@ -226,7 +226,7 @@ export async function getTopMediaItems(
 // Maps Tautulli's English day-of-week labels to a fixed index (0 = Sunday) so
 // the peak day is resolved from the actual label rather than its array
 // position, which shifts with Tautulli's `week_start_monday` setting.
-const DAY_NAME_TO_INDEX: Record<string, number> = {
+const DAY_NAME_TO_INDEX: Record<string, number | undefined> = {
   Sunday: 0,
   Monday: 1,
   Tuesday: 2,
@@ -239,12 +239,12 @@ const DAY_NAME_TO_INDEX: Record<string, number> = {
 // Sums every series ('TV', 'Movies', 'Music', ...) into a single per-category
 // total, keeping the same order as `categories`.
 function sumGraphSeries(graph?: TautulliGraph): number[] {
-  if (!graph?.categories?.length) {
+  if (!graph?.categories?.length || !Array.isArray(graph.series)) {
     return []
   }
 
   return graph.categories.map((_, index) =>
-    graph.series.reduce((sum, serie) => sum + (serie.data[index] ?? 0), 0),
+    graph.series.reduce((sum, serie) => sum + (serie.data?.[index] ?? 0), 0),
   )
 }
 


### PR DESCRIPTION
Adds two new **Rewind** story slides built from Tautulli playback data:

- **Favorite day** — busiest day of the week (`get_plays_by_dayofweek`)
- **Prime time** — peak hour of the day (`get_plays_by_hourofday`)

Each slide renders an animated bar chart (`RewindBarChart`) with:
- A "nice"-rounded Y-axis scale + gridlines
- A gold-highlighted, always-labelled peak bar with edge-clamped labels (no clipping)
- Locale-aware day/hour labels via `Intl` (only the two headline strings are translated)
- A loader before render, and taller sizing on small screens