### PR TITLE
refactor(rewind): drop the end date setting

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -143,13 +143,10 @@
     },
     "Rewind": {
       "title": "Rewind Einstellungen",
-      "endDateMustBeAfterStartDateError": "Enddatum muss nach dem Startdatum sein",
-      "startDateMustBeBeforeEndDateError": "Startdatum muss vor dem Enddatum sein",
       "cards": "Karten",
       "librariesSizeAndCountCard": "Bibliothekengröße & Anzahl Karte",
       "librariesSizeAndCountCardDescription": "Ausschalten, wenn diese Statisiken nicht genutzt werden sollen.",
-      "startDateHelperText": "Standardmäßig die letzten 356 Tage.",
-      "endDateHelperText": "Standardmäßig heute."
+      "startDateHelperText": "Standardmäßig die letzten 356 Tage."
     }
   },
   "LocaleSelect": {
@@ -171,7 +168,6 @@
     "size": "Größe",
     "defaults": "Standard",
     "startDate": "Startdatum",
-    "endDate": "Enddatum",
     "profilePictureAlt": "Profilbild",
     "time": {
       "zero": "0 Minuten",

--- a/messages/de.json
+++ b/messages/de.json
@@ -146,7 +146,7 @@
       "cards": "Karten",
       "librariesSizeAndCountCard": "Bibliothekengröße & Anzahl Karte",
       "librariesSizeAndCountCardDescription": "Ausschalten, wenn diese Statisiken nicht genutzt werden sollen.",
-      "startDateHelperText": "Standardmäßig die letzten 356 Tage."
+      "startDateHelperText": "Standardmäßig die letzten 365 Tage."
     }
   },
   "LocaleSelect": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -143,13 +143,10 @@
     },
     "Rewind": {
       "title": "Rewind settings",
-      "endDateMustBeAfterStartDateError": "End date must be after start date",
-      "startDateMustBeBeforeEndDateError": "Start date must be before end date",
       "cards": "Cards",
       "librariesSizeAndCountCard": "Libraries size & count card",
       "librariesSizeAndCountCardDescription": "Disable if you don't want to rely on Tautulli for these stats.",
-      "startDateHelperText": "Defaults to 365 days ago.",
-      "endDateHelperText": "Defaults to today."
+      "startDateHelperText": "Defaults to 365 days ago."
     }
   },
   "LocaleSelect": {
@@ -171,7 +168,6 @@
     "size": "Size",
     "defaults": "Defaults",
     "startDate": "Start date",
-    "endDate": "End date",
     "profilePictureAlt": "profile picture",
     "time": {
       "zero": "0 mins",

--- a/messages/et.json
+++ b/messages/et.json
@@ -143,13 +143,10 @@
     },
     "Rewind": {
       "title": "Rewind seaded",
-      "endDateMustBeAfterStartDateError": "Lõpp peab olema pärast algust",
-      "startDateMustBeBeforeEndDateError": "Algus peab olema enne lõppu",
       "cards": "Kaardid",
       "librariesSizeAndCountCard": "Kogumike failisuuruse kaart",
       "librariesSizeAndCountCardDescription": "Lülita välja, kui ei soovi sõltuda Tautulli'st failisuuruste jaoks.",
-      "startDateHelperText": "Vaikimisi 365 päeva tagasi.",
-      "endDateHelperText": "Vaikeväärtuseks on täna."
+      "startDateHelperText": "Vaikimisi 365 päeva tagasi."
     }
   },
   "LocaleSelect": {
@@ -171,7 +168,6 @@
     "size": "Suurus",
     "defaults": "Vaikeväärtused",
     "startDate": "Algus",
-    "endDate": "Lõppkuupäev",
     "profilePictureAlt": "profiilipilt",
     "time": {
       "zero": "0 min",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -143,13 +143,10 @@
     },
     "Rewind": {
       "title": "Paramètres Rewind",
-      "endDateMustBeAfterStartDateError": "La date de fin doit être après la date de début",
-      "startDateMustBeBeforeEndDateError": "La date de début doit être avant la date de fin",
       "cards": "Cartes",
       "librariesSizeAndCountCard": "Carte taille et nombre de bibliothèques",
       "librariesSizeAndCountCardDescription": "Désactiver si vous ne voulez pas dépendre de Tautulli pour ces statistiques.",
-      "startDateHelperText": "Par défaut, 365 jours avant.",
-      "endDateHelperText": "Par défaut, aujourd'hui."
+      "startDateHelperText": "Par défaut, 365 jours avant."
     }
   },
   "LocaleSelect": {
@@ -171,7 +168,6 @@
     "size": "Taille",
     "defaults": "Par défaut",
     "startDate": "Date de début",
-    "endDate": "Date de fin",
     "profilePictureAlt": "photo de profil",
     "time": {
       "zero": "0 min",

--- a/src/app/rewind/_components/Stories/Welcome.tsx
+++ b/src/app/rewind/_components/Stories/Welcome.tsx
@@ -1,5 +1,5 @@
 import { RewindStory } from '@/types/rewind'
-import { getRewindDateRange } from '@/utils/helpers'
+import { getRewindStartDate } from '@/utils/helpers'
 import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import RewindStat from '../RewindStat'
@@ -17,11 +17,12 @@ export default function StoryWelcome({
   isPaused,
   settings,
 }: RewindStory) {
-  const { startDate, endDate } = getRewindDateRange(settings)
-  const isDefaultPeriod = !settings.rewind.startDate && !settings.rewind.endDate
+  const startDate = getRewindStartDate(settings)
+  const isDefaultPeriod = !settings.rewind.startDate
   const t = useTranslations('Rewind.Welcome')
   const formattedStartDate = formatDate(startDate)
-  const formattedEndDate = formatDate(endDate)
+  // The window always runs to now, so the displayed range ends today.
+  const formattedEndDate = formatDate(new Date().toISOString().split('T')[0])
 
   return (
     <>

--- a/src/app/rewind/page.tsx
+++ b/src/app/rewind/page.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/utils/getRewind'
 import getSettings from '@/utils/getSettings'
 import getUsersTop from '@/utils/getUsersTop'
-import { getRewindDateRange } from '@/utils/helpers'
+import { daysBetween, getRewindStartDate } from '@/utils/helpers'
 import { Metadata } from 'next'
 import { getServerSession } from 'next-auth'
 import { getTranslations } from 'next-intl/server'
@@ -62,7 +62,7 @@ async function RewindContent({ userId }: { userId?: string }) {
 
   const t = await getTranslations()
   const libraries = await getLibraries()
-  const { startDate, endDate } = getRewindDateRange(settings)
+  const startDate = getRewindStartDate(settings)
   const [
     topMediaItems,
     topMediaStats,
@@ -79,7 +79,7 @@ async function RewindContent({ userId }: { userId?: string }) {
     getlibrariesTotalSize(libraries),
     getLibrariesTotalDuration(libraries),
     getServerId(),
-    getUsersTop(user.id, startDate, 0, endDate),
+    getUsersTop(user.id, startDate, daysBetween(startDate)),
     getPlaybackHabits(user.id),
   ])
   const userRewind: UserRewind = {

--- a/src/app/settings/rewind/_actions/updateRewindSettings.ts
+++ b/src/app/settings/rewind/_actions/updateRewindSettings.ts
@@ -1,7 +1,6 @@
 'use server'
 
 import { RewindSettings, SettingsFormInitialState } from '@/types/settings'
-import { getTranslations } from 'next-intl/server'
 import { z } from 'zod'
 import updateSettings from '../../_actions/updateSettings'
 
@@ -9,39 +8,12 @@ export default async function saveRewindSettings(
   prevState: SettingsFormInitialState<Partial<RewindSettings>>,
   formData: FormData,
 ) {
-  const t = await getTranslations('Settings.Rewind')
-  const schema = z
-    .object({
-      isActive: z.boolean(),
-      isLibrariesSizeAndCountActive: z.boolean().optional(),
-      startDate: z.string().optional(),
-      endDate: z.string().optional(),
-      complete: z.boolean(),
-    })
-    .refine(
-      (data) => {
-        if (data.startDate && data.endDate) {
-          return new Date(data.startDate) < new Date(data.endDate)
-        }
-
-        return true
-      },
-      {
-        message: t('endDateMustBeAfterStartDateError'),
-      },
-    )
-    .refine(
-      (data) => {
-        if (data.startDate && data.endDate) {
-          return new Date(data.endDate) > new Date(data.startDate)
-        }
-
-        return true
-      },
-      {
-        message: t('startDateMustBeBeforeEndDateError'),
-      },
-    )
+  const schema = z.object({
+    isActive: z.boolean(),
+    isLibrariesSizeAndCountActive: z.boolean().optional(),
+    startDate: z.string().optional(),
+    complete: z.boolean(),
+  })
   const isActive = formData.get('isActive') === 'on'
   const data: Partial<RewindSettings> = {
     isActive,
@@ -52,7 +24,6 @@ export default async function saveRewindSettings(
     data.isLibrariesSizeAndCountActive =
       formData.get('isLibrariesSizeAndCountActive') === 'on'
     data.startDate = formData.get('startDate') as string
-    data.endDate = formData.get('endDate') as string
   }
 
   return await updateSettings(schema, data, 'rewind')

--- a/src/app/settings/rewind/_components/RewindSettingsForm.tsx
+++ b/src/app/settings/rewind/_components/RewindSettingsForm.tsx
@@ -87,13 +87,6 @@ export default function RewindSettingsForm({ settings }: Props) {
               name='startDate'
               defaultValue={rewindSettings.startDate}
             />
-            <DatePicker
-              key={`end-date-${rewindSettings.endDate}`}
-              label={tCommon('endDate')}
-              helperText={t('endDateHelperText')}
-              name='endDate'
-              defaultValue={rewindSettings.endDate}
-            />
           </section>
         </>
       )}

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -28,7 +28,6 @@ export type RewindSettings = {
   isActive: boolean
   isLibrariesSizeAndCountActive: boolean
   startDate?: string
-  endDate?: string
   complete: boolean
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -59,7 +59,6 @@ export const DEFAULT_SETTINGS: Settings = {
     isActive: true,
     isLibrariesSizeAndCountActive: true,
     startDate: '',
-    endDate: '',
     complete: false,
   },
   dashboard: {

--- a/src/utils/getRewind.ts
+++ b/src/utils/getRewind.ts
@@ -12,7 +12,7 @@ import fetchTautulli from './fetchTautulli'
 import { secondsToTime, timeToSeconds } from './formatting'
 import getMediaAdditionalData from './getMediaAdditionalData'
 import getSettings from './getSettings'
-import { daysBetween, getRewindDateRange } from './helpers'
+import { daysBetween, getRewindStartDate } from './helpers'
 
 export async function getTopMediaStats(
   userId: string,
@@ -31,14 +31,13 @@ export async function getTopMediaStats(
   }
 
   async function fetchLibraryData(library: TautulliLibrary) {
-    const { startDate, endDate } = getRewindDateRange(getSettings())
+    const startDate = getRewindStartDate(getSettings())
     const res = await fetchTautulli<{
       recordsFiltered: number
       total_duration: string
     }>('get_history', {
       user_id: userId,
       after: startDate,
-      before: endDate,
       length: 0,
       media_type: mediaTypeMap[library.section_type],
       section_id: library.section_id,
@@ -107,13 +106,12 @@ export async function getlibrariesTotalSize(libraries: TautulliLibrary[]) {
 }
 
 export async function getLibrariesTotalDuration(libraries: TautulliLibrary[]) {
-  const { startDate, endDate } = getRewindDateRange(getSettings())
+  const startDate = getRewindStartDate(getSettings())
   const res = await Promise.all(
     libraries.map((library) => {
       return fetchTautulli<{ total_duration: string }>('get_history', {
         section_id: library.section_id,
         after: startDate,
-        before: endDate,
         length: 0,
       })
     }),
@@ -136,14 +134,13 @@ export async function getUserTotalDuration(
   userId: string,
   libraries: TautulliLibrary[],
 ) {
-  const { startDate, endDate } = getRewindDateRange(getSettings())
+  const startDate = getRewindStartDate(getSettings())
   const res = await Promise.all(
     libraries.map((library) => {
       return fetchTautulli<{ total_duration: string }>('get_history', {
         user_id: userId,
         section_id: library.section_id,
         after: startDate,
-        before: endDate,
         length: 0,
       })
     }),
@@ -171,11 +168,11 @@ export async function getTopMediaItems(
     show: 'top_tv',
     artist: 'top_music',
   }
-  const { startDate, endDate } = getRewindDateRange(getSettings())
-  // Tautulli's get_home_stats has a binding-count bug when before/after are
-  // passed (regression from the SQL injection fix in ae4daba2). Use time_range
-  // in days instead — Tautulli computes the window as `last N days`.
-  const time_range = daysBetween(startDate, endDate)
+  const startDate = getRewindStartDate(getSettings())
+  // get_home_stats only reliably accepts a `time_range` in days (Tautulli
+  // computes the window as `last N days` from today), so the rewind window
+  // always runs from startDate up to now.
+  const time_range = daysBetween(startDate)
   const res = await Promise.all(
     libraries.map(async (library) => {
       const stat = await fetchTautulli<TautulliItem>('get_home_stats', {
@@ -265,11 +262,10 @@ function peakIndex(totals: number[]): number | null {
 }
 
 export async function getPlaybackHabits(userId: string) {
-  const { startDate, endDate } = getRewindDateRange(getSettings())
+  const startDate = getRewindStartDate(getSettings())
   // Like getTopMediaItems, the graph endpoints only accept a `time_range` in
-  // days (last N days), not before/after — so a custom range is approximated
-  // by its length, consistent with the rest of the rewind.
-  const time_range = daysBetween(startDate, endDate)
+  // days (last N days from today), so the window runs from startDate up to now.
+  const time_range = daysBetween(startDate)
   const [hourRes, dayRes] = await Promise.all([
     fetchTautulli<TautulliGraph>('get_plays_by_hourofday', {
       user_id: userId,
@@ -308,8 +304,8 @@ export async function getPlaybackHabits(userId: string) {
 }
 
 export async function getRequestsTotals(userId: string) {
-  const { startDate, endDate } = getRewindDateRange(getSettings())
-  const requests = await fetchOverseerrStats('request', startDate, endDate)
+  const startDate = getRewindStartDate(getSettings())
+  const requests = await fetchOverseerrStats('request', startDate)
 
   return {
     total: requests.length,

--- a/src/utils/getUsersTop.ts
+++ b/src/utils/getUsersTop.ts
@@ -6,7 +6,6 @@ import fetchTautulli, {
   getLibrariesByType,
 } from './fetchTautulli'
 import getSettings from './getSettings'
-import { daysBetween } from './helpers'
 
 type UserRequestCounts =
   | {
@@ -18,7 +17,6 @@ export default async function getUsersTop(
   loggedInUserId: string,
   after: string,
   period?: number,
-  before?: string,
 ): Promise<TautulliItemRow[] | null> {
   const numberOfUsers = 6
   const settings = getSettings()
@@ -32,11 +30,10 @@ export default async function getUsersTop(
   }
 
   const activeLibraries = await getLibraries()
-  // Tautulli's get_home_stats has a binding-count bug when before/after are
-  // passed (regression from the SQL injection fix in ae4daba2). Always use
-  // time_range — derive it from the date window when a before/after range is
-  // supplied (e.g. the rewind page).
-  const time_range = before ? daysBetween(after, before) : period || 30
+  // get_home_stats only reliably accepts a `time_range` in days (last N days
+  // from today), so callers pass the window length as `period`. The per-user
+  // history counts below use `after` directly, also anchored to now.
+  const time_range = period || 30
   // get_home_stats can't exclude users itself, so it still ranks excluded
   // users. Request enough rows that they can't push the users we want to keep
   // out of the window before we filter them out below.
@@ -102,7 +99,6 @@ export default async function getUsersTop(
           const userTotal = await fetchOverseerrStats(
             `user/${overseerrId}/requests`,
             after,
-            ...(before ? [before] : []),
           )
 
           return {
@@ -126,7 +122,6 @@ export default async function getUsersTop(
             user_id: user.user_id,
             after: after,
             section_id: movieLib.section_id,
-            ...(before && { before }),
           },
         )
 
@@ -140,7 +135,6 @@ export default async function getUsersTop(
             user_id: user.user_id,
             after: after,
             section_id: showLib.section_id,
-            ...(before && { before }),
           },
         )
 
@@ -154,7 +148,6 @@ export default async function getUsersTop(
             user_id: user.user_id,
             after: after,
             section_id: audioLibItem.section_id,
-            ...(before && { before }),
           },
         )
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -33,16 +33,16 @@ export function getSettingsPage(missingSettingKey: string): string | undefined {
     ?.href
 }
 
-export function getRewindDateRange(settings: Settings) {
-  const startDate = settings.rewind.startDate || PERIODS.pastYear.string
-  const endDate =
-    settings.rewind.endDate || new Date().toISOString().split('T')[0]
-
-  return { startDate, endDate }
+export function getRewindStartDate(settings: Settings): string {
+  return settings.rewind.startDate || PERIODS.pastYear.string
 }
 
-export function daysBetween(startDate: string, endDate: string): number {
-  const ms = new Date(endDate).getTime() - new Date(startDate).getTime()
+// Whole-day count from `startDate` up to `endDate` (defaults to now). Used to
+// express the rewind window as a rolling `time_range` for the Tautulli stat and
+// graph endpoints that don't accept before/after.
+export function daysBetween(startDate: string, endDate?: string): number {
+  const end = endDate ? new Date(endDate).getTime() : Date.now()
+  const ms = end - new Date(startDate).getTime()
 
   if (!Number.isFinite(ms)) {
     return 1


### PR DESCRIPTION
## Why

The rewind **end date** couldn't be honored consistently, so some stats silently ignored it.

The rewind pulls data through two different Tautulli strategies:

| Strategy | Endpoint | Honors a past end date? |
|---|---|---|
| Exact window | `get_history` with `after`+`before` | ✅ |
| Rolling window | `get_home_stats` / `get_plays_by_*` with `time_range` (last N days from **today**) | ❌ |

Durations and counts use the exact window, but the **top-media lists, playback habits, and the users-top ranking** use the rolling `time_range` endpoints — which only accept a day count anchored to *today* (`get_home_stats`'s `before`/`after` has a known binding-count bug, and the graph endpoints don't accept them at all). So a rewind generated for a fixed *past* window mixed correct historical durations with recent top-items/habits.

## What

Drop the end date entirely. The window is now unambiguous — always **from the start date up to now** — so every data source agrees. The start date is unchanged and still controls how far back the rewind reaches.

- Remove `endDate` from `RewindSettings`, defaults, the settings form, action, and Zod schema
- Replace `getRewindDateRange` with `getRewindStartDate`
- `daysBetween` now defaults its end to *now*; rewind callers pass the start date only
- Welcome story shows the range from the start date to today
- Remove now-unused end-date translation keys across all locales (en/de/et/fr)

The dashboard's separate start-date setting is untouched — it was already correct (single boundary, end is always now).