### PR TITLE
fix: broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ If you like this project and wish to support it, you can do so with a one-time d
 
 ## Star History
 
-<a href="https://www.star-history.com/#RaunoT/plex-rewind&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#RaunoT/plex-rewind&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=RaunoT/plex-rewind&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=RaunoT/plex-rewind&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=RaunoT/plex-rewind&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=RaunoT/plex-rewind&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=RaunoT/plex-rewind&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=RaunoT/plex-rewind&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub API restrictions. This switches it to a working star history service so the chart renders again.